### PR TITLE
add link to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 unicode-security-guide
 ======================
 
-A repository for the *Unicode Security Guide*.
+A repository for the [*Unicode Security Guide*](http://cweb.github.io/unicode-security-guide/).
 
 Push all commits to the _gh-pages_ branch.


### PR DESCRIPTION
I was on the unicode-security-guide repo and thinking _where's the website?_ so I added a link in the readme file for easy access. I'd also recommend adding it to the _Website_ box when editing the repo description.

Thanks for the great guide!
